### PR TITLE
Fix variables in include paths

### DIFF
--- a/Wrapper.gd
+++ b/Wrapper.gd
@@ -1,6 +1,7 @@
 extends Node
 
 var xml2json = load("res://XML2JSON.gd").new()
+var PropertyWrapper = preload("res://PropertyWrapper.gd").new()
 
 # Holds mapping between files and content; this is because themes cross-reference files
 var xml_filemap := {}
@@ -46,6 +47,7 @@ func map_xml_content(dict: Dictionary, root_path: String):
 					map_xml_content(val, root_path)
 
 func expand_file_path(path: String, root_path: String):
+	path = PropertyWrapper.parse_string(self, path)
 	if path[0] == '.':
 		path = root_path + path.substr(1)
 	elif path[0] == '~':

--- a/project.godot
+++ b/project.godot
@@ -44,6 +44,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/controller_icons/objects/TextureRect.gd"
 }, {
+"base": "TextureRect",
+"class": "LazyTextureRect",
+"language": "GDScript",
+"path": "res://addons/retrohub_theme_helper/ui/LazyTextureRect.gd"
+}, {
 "base": "Resource",
 "class": "RetroHubGameData",
 "language": "GDScript",
@@ -67,6 +72,7 @@ _global_script_class_icons={
 "ControllerSprite": "",
 "ControllerSprite3D": "",
 "ControllerTextureRect": "",
+"LazyTextureRect": "",
 "RetroHubGameData": "",
 "RetroHubGameMediaData": "",
 "RetroHubSystemData": ""
@@ -83,10 +89,10 @@ config/icon="res://icon.png"
 ControllerIcons="*res://addons/controller_icons/ControllerIcons.gd"
 JSONUtils="*res://addons/retrohub_theme_helper/utils/JSONUtils.gd"
 FileUtils="*res://addons/retrohub_theme_helper/utils/FileUtils.gd"
-RetroHubConfig="*res://addons/retrohub_theme_helper/Config.gd"
-RetroHubUI="*res://addons/retrohub_theme_helper/UI.gd"
-RetroHubMedia="*res://addons/retrohub_theme_helper/Media.gd"
-RetroHub="*res://addons/retrohub_theme_helper/RetroHub.gd"
+RetroHubConfig="*res://addons/retrohub_theme_helper/singletons/Config.gd"
+RetroHubUI="*res://addons/retrohub_theme_helper/singletons/UI.gd"
+RetroHubMedia="*res://addons/retrohub_theme_helper/singletons/Media.gd"
+RetroHub="*res://addons/retrohub_theme_helper/singletons/RetroHub.gd"
 RegionUtils="*res://addons/retrohub_theme_helper/utils/RegionUtils.gd"
 
 [display]


### PR DESCRIPTION
Some themes may have variables in their include paths. These were being ignored, causing it to default to the original path and creating a stack overflow.

Some other things changed by Godot due to updating the theme helper addon as well